### PR TITLE
Accidental overwrite

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -58,12 +58,12 @@ declare module "josh" {
     public dec(keyOrPath: string): Promise<Josh<T>>;
 
     public find(
-      valueOrFn: string | ((value: T) => Promise<boolean>),
+      valueOrFn: string | ((value: T) => Promise<boolean> | boolean),
       path?: string
     ): Promise<[string, T]>;
 
     public filter(
-      valueOrFn: string | ((value: T) => Promise<boolean>),
+      valueOrFn: string | ((value: T) => Promise<boolean> | boolean),
       path?: string
     ): Promise<[string, T][]>;
 


### PR DESCRIPTION
Fixed `find()` and `filter()` first parameter function return type to `Promise<boolean> | boolean>` from `Promise<boolean>`. Was this way before, just an accidental overwrite.