### PR TITLE
typings: add export

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -74,5 +74,7 @@ declare module "josh" {
       overwrite?: boolean,
       clear?: boolean
     ): Promise<Josh<T>>;
+
+    public export(): Promise<string>;
   }
 }


### PR DESCRIPTION
This PR adds the typings for `#export()`.