### PR TITLE
Added keys to serializers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -126,7 +126,7 @@ class Josh {
     } else {
       value = await this.provider.get(key);
     }
-    value = this.deserializer ? this.deserializer(value, key) : value;
+    value = this.deserializer ? this.deserializer(value, key, path) : value;
     return path.length ? _get(value, path) : value;
   }
 
@@ -142,7 +142,7 @@ class Josh {
     await this.readyCheck();
     if (keysOrPaths === this.all) {
       const allValues = await this.provider.getAll();
-      return this.deserializer ? allValues.map(value => [value[0], this.deserializer(value[1], value[0])]) : allValues;
+      return this.deserializer ? allValues.map(value => [value[0], this.deserializer(value[1], value[0], '')]) : allValues;
     }
     if (!isArray(keysOrPaths)) {
       throw new Err('This function requires an array of keys or values', 'JoshArgumentError');
@@ -151,7 +151,7 @@ class Josh {
     return data.map((value, index) => {
       const [, ...path] = keysOrPaths[index].split('.');
       if (this.deserializer) {
-        value = [value[0], this.deserializer(value[1], value[0])];
+        value = [value[0], this.deserializer(value[1], value[0], '')];
       }
       return path.length ? [keysOrPaths[index], _get(value, path)] : [keysOrPaths[index], value];
     });
@@ -238,7 +238,7 @@ class Josh {
     await this.readyCheck();
     // await this.provider.keyCheck(keyOrPath);
     const [key, path] = this.getKeyAndPath(keyOrPath);
-    await this.provider.set(key, path, this.serializer ? this.serializer(value, key) : value);
+    await this.provider.set(key, path, this.serializer ? this.serializer(value, key, path) : value);
     return this;
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -126,7 +126,7 @@ class Josh {
     } else {
       value = await this.provider.get(key);
     }
-    value = this.deserializer ? this.deserializer(value) : value;
+    value = this.deserializer ? this.deserializer(value, key) : value;
     return path.length ? _get(value, path) : value;
   }
 
@@ -142,7 +142,7 @@ class Josh {
     await this.readyCheck();
     if (keysOrPaths === this.all) {
       const allValues = await this.provider.getAll();
-      return this.deserializer ? allValues.map(this.deserializer) : allValues;
+      return this.deserializer ? allValues.map(value => [value[0], this.deserializer(value[1], value[0])]) : allValues;
     }
     if (!isArray(keysOrPaths)) {
       throw new Err('This function requires an array of keys or values', 'JoshArgumentError');
@@ -151,7 +151,7 @@ class Josh {
     return data.map((value, index) => {
       const [, ...path] = keysOrPaths[index].split('.');
       if (this.deserializer) {
-        value = this.deserializer(value);
+        value = [value[0], this.deserializer(value[1], value[0])];
       }
       return path.length ? [keysOrPaths[index], _get(value, path)] : [keysOrPaths[index], value];
     });
@@ -238,7 +238,7 @@ class Josh {
     await this.readyCheck();
     // await this.provider.keyCheck(keyOrPath);
     const [key, path] = this.getKeyAndPath(keyOrPath);
-    await this.provider.set(key, path, this.serializer ? this.serializer(value) : value);
+    await this.provider.set(key, path, this.serializer ? this.serializer(value, key) : value);
     return this;
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -126,7 +126,7 @@ class Josh {
     } else {
       value = await this.provider.get(key);
     }
-    value = this.deserializer ? this.deserializer(value, key, path) : value;
+    value = this.deserializer ? this.deserializer(value, key, path.join('.')) : value;
     return path.length ? _get(value, path) : value;
   }
 
@@ -142,16 +142,20 @@ class Josh {
     await this.readyCheck();
     if (keysOrPaths === this.all) {
       const allValues = await this.provider.getAll();
-      return this.deserializer ? allValues.map(value => [value[0], this.deserializer(value[1], value[0], '')]) : allValues;
+      return this.deserializer ? allValues.map(value => {
+        const [key, content] = value;
+        return [key, this.deserializer(content, key, null)];
+      }) : allValues;
     }
     if (!isArray(keysOrPaths)) {
       throw new Err('This function requires an array of keys or values', 'JoshArgumentError');
     }
     const data = await this.provider.getMany(keysOrPaths.map(str => str.split('.')[0]));
     return data.map((value, index) => {
-      const [, ...path] = keysOrPaths[index].split('.');
+      const [key, ...path] = keysOrPaths[index].split('.');
       if (this.deserializer) {
-        value = [value[0], this.deserializer(value[1], value[0], '')];
+        const [, content] = value;
+        value = [key, this.deserializer(content, key, path)];
       }
       return path.length ? [keysOrPaths[index], _get(value, path)] : [keysOrPaths[index], value];
     });


### PR DESCRIPTION
This allows serializers to be given the key. This is useful in for example a discord bot where it has roles stored. The user can then use the key to get the guild and doesn't need to store the guild.