### PR TITLE
Fix GetMany and Deserializer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -103,9 +103,9 @@ class Josh {
   * Internal Method. Splits the key and path
   */
   getKeyAndPath(keyOrPath) {
-    if(!keyOrPath) throw new Err('KeyOrPath must not be null.')
-    const [key, ...path] = keyOrPath.split(".");
-    return [key, path.join(".")];
+    if (!keyOrPath) throw new Err('KeyOrPath must not be null.');
+    const [key, ...path] = keyOrPath.split('.');
+    return [key, path.join('.')];
   }
 
   /**
@@ -126,7 +126,7 @@ class Josh {
     } else {
       value = await this.provider.get(key);
     }
-    value = this.deserializer ? this.deserializer(value, key, path.join('.')) : value;
+    value = this.deserializer ? this.deserializer(value, key, path) : value;
     return path.length ? _get(value, path) : value;
   }
 
@@ -151,14 +151,15 @@ class Josh {
       throw new Err('This function requires an array of keys or values', 'JoshArgumentError');
     }
     const data = await this.provider.getMany(keysOrPaths.map(str => str.split('.')[0]));
-    return data.map((value, index) => {
-      const [key, ...path] = keysOrPaths[index].split('.');
+    keysOrPaths.forEach((keyOrPath) => {
+      const [key, ...path] = keyOrPath.split('.');
+      let value = data[key];
       if (this.deserializer) {
-        const [, content] = value;
-        value = [key, this.deserializer(content, key, path)];
+        value = this.deserializer(value, key, path);
       }
-      return path.length ? [keysOrPaths[index], _get(value, path)] : [keysOrPaths[index], value];
+      data[key] = path.length ? _get(value, path) : value;
     });
+    return data;
   }
 
   /**
@@ -197,7 +198,7 @@ class Josh {
     try {
       const [key, path] = this.getKeyAndPath(keyOrPath);
       return this.provider.has(key, path);
-    } catch(err) {
+    } catch (err) {
       console.log(keyOrPath);
       console.log(`Error on ${keyOrPath}: ${err}`);
       return null;
@@ -545,7 +546,7 @@ class Josh {
       name: this.name,
       version: pkgdata.version,
       exportDate: Date.now(),
-      keys: data.map(([key, value]) => ({ key, value }))
+      keys: data.map(([key, value]) => ({ key, value })),
     }, null, 2);
   }
 


### PR DESCRIPTION
I pushed a fix to support the new GetMany Format.
I fixed one instance where it used .join but didn't need to, in deserializer code.
I did run my eslint and that changed some spacing and quotes, I can make another commit to fix that if you like.